### PR TITLE
Fixed secure callback flag not respecting current protocol.

### DIFF
--- a/modules/integration_report_example/src/IntegrationReportExample1.php
+++ b/modules/integration_report_example/src/IntegrationReportExample1.php
@@ -8,6 +8,8 @@ use Symfony\Component\HttpFoundation\Response;
 
 /**
  * Class IntegrationReportExample1.
+ *
+ * Example for the IntegrationReport module.
  */
 class IntegrationReportExample1 extends IntegrationReport {
 

--- a/modules/integration_report_example/src/IntegrationReportExample2.php
+++ b/modules/integration_report_example/src/IntegrationReportExample2.php
@@ -9,6 +9,8 @@ use Symfony\Component\HttpFoundation\Response;
 
 /**
  * Class IntegrationReportExample2.
+ *
+ * Example for the IntegrationReport module.
  */
 class IntegrationReportExample2 extends IntegrationReport {
 

--- a/src/Controller/IntegrationReportController.php
+++ b/src/Controller/IntegrationReportController.php
@@ -16,6 +16,8 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * Class IntegrationReportController.
  *
+ * Controller for integration report.
+ *
  * @package Drupal\dblog\Controller
  */
 class IntegrationReportController extends ControllerBase {

--- a/src/Controller/IntegrationReportController.php
+++ b/src/Controller/IntegrationReportController.php
@@ -108,7 +108,7 @@ class IntegrationReportController extends ControllerBase {
       if ($report->useCallback) {
         $url_attributes = [
           'absolute' => TRUE,
-          'https' => $report->secureCallback ? TRUE : FALSE,
+          'https' => $report->secureCallback,
         ];
         $iframe_url = Url::fromUserInput('/admin/reports/integrations/' . $class_name, $url_attributes);
         $table['#suffix'] .= new FormattableMarkup('<div class="integration-report-debug-result" data-debug-result="@class_name"><strong>Content debug for @report_name</strong><br/><iframe src="@iframe_url"></iframe></div>', [

--- a/src/IntegrationReport.php
+++ b/src/IntegrationReport.php
@@ -45,7 +45,9 @@ abstract class IntegrationReport {
   /**
    * Whether the status callback needs to be performed over https.
    *
-   * @var bool
+   * If NULL, then the current protocol will be used.
+   *
+   * @var bool|null
    */
   public $secureCallback;
 
@@ -62,7 +64,7 @@ abstract class IntegrationReport {
         $this->js = $info['js'];
       }
       $this->useCallback = isset($info['use_callback']) ? $info['use_callback'] : TRUE;
-      $this->secureCallback = isset($info['secure_callback']) ? $info['secure_callback'] : FALSE;
+      $this->secureCallback = isset($info['secure_callback']) ? $info['secure_callback'] : NULL;
     }
   }
 

--- a/src/IntegrationReportHelperTrait.php
+++ b/src/IntegrationReportHelperTrait.php
@@ -5,6 +5,8 @@ namespace Drupal\integration_report;
 /**
  * Trait IntegrationReportHelperTrait.
  *
+ * Utilities for the integration report.
+ *
  * @package Drupal\integration_report
  */
 trait IntegrationReportHelperTrait {


### PR DESCRIPTION
Currently, the iframe URL is generated based on the `secureCallback` flag that may or may not be set within the implementing class. If it is not set, the value of the flag is set to `FALSE`, which is then passed to the `Url()` where it is interpreted as force 'http'. 

This PR fixes this behaviour by preserving `NULL` (unset) value of the flag so that `Url()` could treat it as `NULL` if it is not set, meaning to respect current protocol.