### PR TITLE
Added support for JS tests.

### DIFF
--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -86,6 +86,35 @@ commands:
       php -d pcov.directory=.. vendor/bin/phpunit --testsuite functional "$@"
       popd >/dev/null || exit 1
 
+
+  test-functional-javascript:
+    usage: Run FunctionalJavascript tests.
+    cmd: |
+      ahoy selenium-start
+      pushd "build" >/dev/null || exit 1
+      php -d pcov.directory=.. vendor/bin/phpunit --testsuite functional-javascript "$@"
+      popd >/dev/null || exit 1
+
+  selenium-start:
+    usage: Start Selenium container if not already running.
+    cmd: |
+      if curl -s http://localhost:4444/status | grep -q '"ready": true'; then
+        echo "Selenium container is already running."
+        exit 0
+      fi
+      docker rm -f selenium 2>/dev/null || true
+      docker run -d --name selenium -p 4444:4444 selenium/standalone-chromium:145.0
+      echo "Waiting for Selenium to be ready..."
+      for i in $(seq 1 30); do curl -s http://localhost:4444/status | grep -q '"ready": true' && break; sleep 1; done
+      if ! curl -s http://localhost:4444/status | grep -q '"ready": true'; then
+        echo "ERROR: Selenium failed to become ready after 30 seconds."
+        exit 1
+      fi
+
+  selenium-stop:
+    usage: Stop Selenium container.
+    cmd: docker rm -f selenium 2>/dev/null || true
+
   reset:
     usage: Reset project to the default state.
     cmd: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,6 +81,12 @@ jobs:
             php-version: 8.4
             drupal-version: 11@beta
 
+    services:
+      chrome:
+        image: selenium/standalone-chromium:145.0
+        ports:
+          - 4444:4444
+
     name: ${{ matrix.name }}
 
     env:
@@ -128,6 +134,8 @@ jobs:
 
       - name: Start built-in PHP server
         run: .devtools/start
+        env:
+          WEBSERVER_HOST: 0.0.0.0
 
       - name: Provision site
         run: .devtools/provision

--- a/README.md
+++ b/README.md
@@ -167,9 +167,22 @@ the tests.
 
 The `test` command is a wrapper for multiple test commands:
 ```bash
-ahoy test-unit        # Run Unit tests
-ahoy test-kernel      # Run Kernel tests
-ahoy test-functional  # Run Functional tests
+ahoy test-unit           # Run Unit tests
+ahoy test-kernel         # Run Kernel tests
+ahoy test-functional     # Run Functional tests
+ahoy test-functional-javascript  # Run FunctionalJavascript tests
+```
+
+### Running FunctionalJavascript tests
+
+FunctionalJavascript tests require a browser controlled via WebDriver.
+
+```bash
+ahoy selenium-start
+WEBSERVER_HOST=0.0.0.0 ahoy start
+ahoy provision
+ahoy test-functional-javascript
+ahoy selenium-stop
 ```
 
 ### Running specific tests

--- a/phpunit.d10.xml
+++ b/phpunit.d10.xml
@@ -64,7 +64,7 @@
         <!-- Example for changing the driver args to mink tests MINK_DRIVER_ARGS value: '["http://127.0.0.1:8510"]' -->
         <env name="MINK_DRIVER_ARGS" value=''/>
         <!-- Example for changing the driver args to webdriver tests MINK_DRIVER_ARGS_WEBDRIVER value: '["chrome", { "chromeOptions": { "w3c": false } }, "http://localhost:4444/wd/hub"]' For using the Firefox browser, replace "chrome" with "firefox" -->
-        <env name="MINK_DRIVER_ARGS_WEBDRIVER" value=''/>
+        <env name="MINK_DRIVER_ARGS_WEBDRIVER" value='["chrome", {"goog:chromeOptions": {"w3c": true, "args": ["--no-sandbox", "--disable-gpu", "--window-size=1280,1024"]}}, "http://localhost:4444"]' force="true"/>
     </php>
     <testsuites>
         <testsuite name="unit">
@@ -80,13 +80,10 @@
             <directory>web/themes/custom/*/tests/src/Functional</directory>
         </testsuite>
 
-        <!-- Not implemented. -->
-        <!-- See https://github.com/drevops/scaffold/issues/820 -->
-        <!--
         <testsuite name="functional-javascript">
-          <file>./tests/TestSuites/FunctionalJavascriptTestSuite.php</file>
+            <directory>web/modules/custom/*/tests/src/FunctionalJavascript</directory>
+            <directory>web/themes/custom/*/tests/src/FunctionalJavascript</directory>
         </testsuite>
-        -->
     </testsuites>
 
     <logging>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -54,7 +54,7 @@
         <!-- Example for changing the driver args to mink tests MINK_DRIVER_ARGS value: '["http://127.0.0.1:8510"]' -->
         <env name="MINK_DRIVER_ARGS" value=""/>
         <!-- Example for changing the driver args to webdriver tests MINK_DRIVER_ARGS_WEBDRIVER value: '["chrome", { "goog:chromeOptions": { "w3c": false } }, "http://localhost:4444/wd/hub"]' For using the Firefox browser, replace "chrome" with "firefox" -->
-        <env name="MINK_DRIVER_ARGS_WEBDRIVER" value=""/>
+        <env name="MINK_DRIVER_ARGS_WEBDRIVER" value='["chrome", {"browserName": "chrome", "goog:chromeOptions": {"w3c": true, "args": ["--no-sandbox", "--disable-gpu", "--window-size=1280,1024"]}}, "http://localhost:4444"]' force="true"/>
     </php>
     <extensions>
         <!-- Functional tests HTML output logging. -->
@@ -90,13 +90,10 @@
             <directory>web/themes/custom/*/tests/src/Functional</directory>
         </testsuite>
 
-        <!-- Not implemented. -->
-        <!-- See https://github.com/drevops/vortex/issues/820 -->
-        <!--
         <testsuite name="functional-javascript">
-          <file>./tests/TestSuites/FunctionalJavascriptTestSuite.php</file>
+            <directory>web/modules/custom/*/tests/src/FunctionalJavascript</directory>
+            <directory>web/themes/custom/*/tests/src/FunctionalJavascript</directory>
         </testsuite>
-        -->
     </testsuites>
 
     <logging>

--- a/src/Controller/IntegrationReportController.php
+++ b/src/Controller/IntegrationReportController.php
@@ -7,6 +7,7 @@ namespace Drupal\integration_report\Controller;
 use Drupal\Component\Render\FormattableMarkup;
 use Drupal\Component\Utility\Html;
 use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Render\RendererInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\Url;
 use Drupal\integration_report\IntegrationReportHelperTrait;
@@ -43,7 +44,8 @@ class IntegrationReportController extends ControllerBase {
   public static function create(ContainerInterface $container): IntegrationReportController {
     // @phpstan-ignore-next-line
     return new static(
-      $container->get('integration_report.report_manager')
+      $container->get('integration_report.report_manager'),
+      $container->get('renderer')
     );
   }
 
@@ -52,9 +54,12 @@ class IntegrationReportController extends ControllerBase {
    *
    * @param \Drupal\integration_report\IntegrationReportManager $report_manager
    *   The report manager.
+   * @param \Drupal\Core\Render\RendererInterface $renderer
+   *   The renderer service.
    */
-  public function __construct(IntegrationReportManager $report_manager) {
+  public function __construct(IntegrationReportManager $report_manager, RendererInterface $renderer) {
     $this->reportManager = $report_manager;
+    $this->renderer = $renderer;
   }
 
   /**

--- a/tests/src/Functional/IntegrationReportTest.php
+++ b/tests/src/Functional/IntegrationReportTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Drupal\Tests\integration_report\FunctionalJavascript;
+namespace Drupal\Tests\integration_report\Functional;
 
 use Drupal\Tests\BrowserTestBase;
 

--- a/tests/src/FunctionalJavascript/IntegrationReportJsTestBase.php
+++ b/tests/src/FunctionalJavascript/IntegrationReportJsTestBase.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\integration_report\FunctionalJavascript;
+
+use Drupal\FunctionalJavascriptTests\WebDriverTestBase;
+
+/**
+ * Base class for Integration Report JavaScript functional tests.
+ *
+ * @group integration_report
+ */
+abstract class IntegrationReportJsTestBase extends WebDriverTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $defaultTheme = 'stark';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = ['integration_report'];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    // Override SIMPLETEST_BASE_URL for Docker-based Selenium: Chrome inside
+    // the container cannot reach 'localhost' on the host machine.
+    $port = getenv('WEBSERVER_PORT') ?: '8000';
+    $host = PHP_OS_FAMILY === 'Darwin' ? 'host.docker.internal' : '172.17.0.1';
+    putenv('SIMPLETEST_BASE_URL=http://' . $host . ':' . $port);
+    parent::setUp();
+  }
+
+  /**
+   * Create a screenshot with an auto-generated filename.
+   *
+   * Filename format: {ms_timestamp}-{Class}-{method}-L{line}.png.
+   *
+   * @param bool $set_background_color
+   *   (optional) Whether to set the background color. Defaults to TRUE.
+   */
+  protected function createAutoScreenshot(bool $set_background_color = TRUE): void {
+    $trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2);
+
+    $line = $trace[0]['line'] ?? 0;
+    $class = str_replace('\\', '_', $trace[1]['class'] ?? 'Unknown');
+    $method = $trace[1]['function'];
+    $timestamp = (int) (microtime(TRUE) * 1000);
+
+    $filename = sprintf('%d-%s-%s-L%d.png', $timestamp, $class, $method, $line);
+    $path = \Drupal::root() . '/sites/simpletest/browser_output/' . $filename;
+
+    $this->createScreenshot($path, $set_background_color);
+    $this->assertFileExists($path);
+  }
+
+}

--- a/tests/src/FunctionalJavascript/IntegrationReportSmokeJsTest.php
+++ b/tests/src/FunctionalJavascript/IntegrationReportSmokeJsTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\integration_report\FunctionalJavascript;
+
+/**
+ * Smoke test validating the WebDriver and screenshot pipeline.
+ *
+ * @group integration_report
+ */
+class IntegrationReportSmokeJsTest extends IntegrationReportJsTestBase {
+
+  /**
+   * Tests WebDriver connectivity and screenshot generation.
+   */
+  public function testSmokeWebDriver(): void {
+    // Verify unauthenticated page renders.
+    $this->drupalGet('/user/login');
+    $this->createAutoScreenshot();
+
+    // Create user and log in.
+    $account = $this->drupalCreateUser(['access integration report']);
+    $this->assertNotEmpty($account);
+    $this->drupalLogin($account);
+
+    // Verify authenticated page renders.
+    $this->drupalGet('<front>');
+    $this->createAutoScreenshot();
+
+    // Verify Drupal JavaScript API is available.
+    $this->assertJsCondition('typeof Drupal !== "undefined" && typeof Drupal.behaviors !== "undefined"');
+  }
+
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
Adds comprehensive support for FunctionalJavascript tests using WebDriver and Selenium, enabling JavaScript testing capabilities in the integration_report module.

## Changes by File

### `.ahoy.yml`
- Added `test-functional-javascript` command that orchestrates FunctionalJavascript test execution by starting Selenium, setting the test base URL environment variable, and running the functional-javascript PHPUnit test suite.
- Added `selenium-start` command to manage Selenium container lifecycle: checks readiness status, removes any existing container, launches a new Selenium Chrome container, and polls until the container is ready.
- Added `selenium-stop` command to stop and remove the Selenium container.

### `.github/workflows/test.yml`
- Integrated Selenium Chrome service for GitHub Actions with WebDriver port mapping (4444).
- Configured environment variables:
  - `WEBSERVER_HOST=0.0.0.0` to expose the built-in PHP server on all interfaces.
  - `SIMPLETEST_BASE_URL` for test base URL configuration.
  - `MINK_DRIVER_ARGS_WEBDRIVER` to point tests to the Selenium Chrome service endpoint.

### `README.md`
- Added "Running FunctionalJavascript tests" section with complete workflow documentation.
- Documented FunctionalJavascript test requirements (browser controlled via WebDriver).
- Added command examples for the new `test-functional-javascript` workflow including Selenium start/stop steps.

### `phpunit.xml`
- Activated the `functional-javascript` test suite (previously commented out) with test directories:
  - `web/modules/custom/*/tests/src/FunctionalJavascript`
  - `web/themes/custom/*/tests/src/FunctionalJavascript`
- Updated `MINK_DRIVER_ARGS_WEBDRIVER` environment variable with JSON WebDriver configuration and `force="true"` attribute.

### `tests/src/Functional/IntegrationReportTest.php`
- Updated namespace from `Drupal\Tests\integration_report\FunctionalJavascript` to `Drupal\Tests\integration_report\Functional` to correctly reflect the test type.

### `tests/src/FunctionalJavascript/IntegrationReportJsTestBase.php` (New)
- Added base test class `IntegrationReportJsTestBase` extending `WebDriverTestBase` for FunctionalJavascript tests.
- Configured default theme as 'stark' and enabled the `integration_report` module.
- Implemented `createAutoScreenshot()` helper method that generates timestamped screenshots with automatic filename generation based on class name, method, and line number.

### `tests/src/FunctionalJavascript/IntegrationReportSmokeJsTest.php` (New)
- Added smoke test `IntegrationReportSmokeJsTest` extending `IntegrationReportJsTestBase`.
- Implemented `testSmokeWebDriver()` test method that:
  - Accesses unauthenticated `/user/login` page and captures a screenshot.
  - Creates and authenticates a user with the 'access integration report' permission.
  - Accesses front page as an authenticated user and captures a screenshot.
  - Verifies Drupal JavaScript API availability (`Drupal` and `Drupal.behaviors` objects).

### `src/Controller/IntegrationReportController.php`
- Injected `RendererInterface` into the controller via the constructor and service container; updated constructor signature and added the renderer property.

## Summary
This PR establishes a complete JavaScript testing infrastructure for the project by adding Selenium WebDriver integration to local development (.ahoy.yml) and CI workflows, enabling FunctionalJavascript tests to execute against a real browser, and providing base classes and example tests demonstrating the new capability.

## Possibly related
- Possibly related to https://www.drupal.org/node/2626832 (mentioned in phpunit files)
- Possibly related to https://www.drupal.org/node/2116263 (mentioned in phpunit files)
- Possibly related to https://www.drupal.org/node/2992069 (mentioned in phpunit files)
- Possibly related to this project's issue tracker: https://www.drupal.org/project/issues/integration_report
<!-- end of auto-generated comment: release notes by coderabbit.ai -->