### PR TITLE
Update renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,19 +4,21 @@
     "rangeStrategy": "bump",
     "dependencyDashboard": true,
     "pinDigests": true,
-    "major": {
-        "enabled": false
-    },
-    "groupName": "all dependencies",
-    "groupSlug": "all",
     "branchPrefix": "deps/",
-    "composer": {
-        "managerFilePatterns": ["/composer\\.dev\\.json$/"]
-    },
     "packageRules": [
         {
+            "matchDepNames": ["php"],
             "matchManagers": ["composer"],
-            "matchFileNames": ["composer.json"],
+            "enabled": false
+        },
+        {
+            "matchDepNames": ["node", "yarn"],
+            "matchManagers": ["npm"],
+            "enabled": false
+        },
+        {
+            "matchManagers": ["npm", "composer"],
+            "matchUpdateTypes": ["major"],
             "enabled": false
         },
         {


### PR DESCRIPTION
Updated renovate config via 🤠 RepoRanger.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request restructures the Renovate configuration to improve maintainability and clarity by converting implicit global configuration rules into explicit per-rule entries with clear intent.

## Changes

The `renovate.json` file has been refactored to replace global configuration blocks with explicit `packageRules` entries:

- **Removed global configuration**:
  - Eliminated `major` version grouping settings (`groupName`, `groupSlug`)
  - Removed `composer.managerFilePatterns` global constraint

- **Added three explicit `packageRules`**:
  1. Rule targeting PHP (`matchDepNames: ["php"]`) with `composer` manager, disabled
  2. Rule targeting Node.js tooling (`matchDepNames: ["node", "yarn"]`) with `npm` manager, disabled
  3. Rule targeting major version updates across all managers (`matchManagers: ["npm", "composer"]`, `matchUpdateTypes: ["major"]`), disabled

- **Simplified constraints**: Removed file-level `matchFileNames` constraint from per-rule entries

- **Preserved functionality**: The catch-all rule for grouping all remaining dependencies remains unchanged

## Configuration Context

The project maintains active dependency management with Renovate (indicated by badge in README.md) and manages dependencies across multiple managers:
- **PHP/Composer**: `composer.json`, `composer.dev.json`
- **Node/npm**: `package.json`

**Lines changed**: +11/-9  
**Estimated review effort**: Medium

<!-- end of auto-generated comment: release notes by coderabbit.ai -->