### PR TITLE
Added overview controller tests, Jest V8 coverage, and Codecov uploads for Jest.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -234,7 +234,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: ${{github.job}}-code-coverage-report-${{ matrix.name }}
-          path: ./.logs/coverage/phpunit/.coverage-html
+          path: ./.logs/coverage
           include-hidden-files: true
           if-no-files-found: error
 
@@ -242,7 +242,7 @@ jobs:
         uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6
         if: ${{ env.CODECOV_TOKEN != '' }}
         with:
-          files: ./.logs/coverage/phpunit/cobertura.xml
+          files: ./.logs/coverage/phpunit/cobertura.xml,./.logs/coverage/jest/cobertura.xml
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
         env:

--- a/jest.config.js
+++ b/jest.config.js
@@ -12,15 +12,28 @@ dirs.forEach((dir) => {
     fs.readdirSync(dir).forEach((name) => {
       const jsDir = path.resolve(dir, name, 'js');
       if (fs.existsSync(jsDir)) {
-        roots.push(jsDir);
+        roots.push(fs.realpathSync(jsDir));
       }
     });
   }
 });
 
 module.exports = {
+  // V8 coverage tracks files outside rootDir only when rootDir contains them,
+  // so anchor rootDir at the project root rather than the build directory.
+  rootDir: path.resolve(__dirname, '..'),
   testEnvironment: 'jsdom',
   roots,
   testMatch: ['**/*.test.js'],
   testPathIgnorePatterns: ['/node_modules/', '/vendor/'],
+  collectCoverage: true,
+  coverageProvider: 'v8',
+  coveragePathIgnorePatterns: ['/node_modules/', '/vendor/', '\\.test\\.js$'],
+  coverageDirectory: path.resolve(__dirname, '../.logs/coverage/jest'),
+  coverageReporters: [
+    'text',
+    ['html', { subdir: '.coverage-html' }],
+    ['cobertura', { file: 'cobertura.xml' }],
+  ],
+  modulePaths: [path.resolve(__dirname, 'node_modules')],
 };

--- a/modules/integration_report_example/src/IntegrationReportExample1.php
+++ b/modules/integration_report_example/src/IntegrationReportExample1.php
@@ -15,6 +15,8 @@ use Symfony\Component\HttpFoundation\Response;
  * Class IntegrationReportExample1.
  *
  * Example for the IntegrationReport module.
+ *
+ * @codeCoverageIgnore
  */
 class IntegrationReportExample1 extends IntegrationReportBase {
 

--- a/modules/integration_report_example/src/IntegrationReportExample2.php
+++ b/modules/integration_report_example/src/IntegrationReportExample2.php
@@ -17,6 +17,8 @@ use Symfony\Component\HttpFoundation\Response;
  * Class IntegrationReportExample2.
  *
  * Example for the IntegrationReport module.
+ *
+ * @codeCoverageIgnore
  */
 class IntegrationReportExample2 extends IntegrationReportBase {
 

--- a/tests/src/Unit/Controller/IntegrationReportControllerTest.php
+++ b/tests/src/Unit/Controller/IntegrationReportControllerTest.php
@@ -5,7 +5,11 @@ declare(strict_types=1);
 namespace Drupal\Tests\integration_report\Unit\Controller;
 
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\Core\Path\PathValidatorInterface;
+use Drupal\Core\Render\Markup;
 use Drupal\Core\Render\RendererInterface;
+use Drupal\Core\Routing\UrlGeneratorInterface;
+use Drupal\Core\Utility\UnroutedUrlAssemblerInterface;
 use Drupal\integration_report\Controller\IntegrationReportController;
 use Drupal\integration_report\IntegrationReportInterface;
 use Drupal\integration_report\IntegrationReportManager;
@@ -40,8 +44,20 @@ class IntegrationReportControllerTest extends UnitTestCase {
     $logger_factory = $this->createMock(LoggerChannelFactoryInterface::class);
     $logger_factory->method('get')->willReturn($this->logger);
 
+    $path_validator = $this->createMock(PathValidatorInterface::class);
+    $path_validator->method('getUrlIfValidWithoutAccessCheck')->willReturn(FALSE);
+
+    $unrouted_url_assembler = $this->createMock(UnroutedUrlAssemblerInterface::class);
+    $unrouted_url_assembler->method('assemble')->willReturnCallback(function (string $uri): string {
+      return '/' . str_replace(['internal:/', 'base:'], '', $uri);
+    });
+
     $container = new ContainerBuilder();
     $container->set('logger.factory', $logger_factory);
+    $container->set('string_translation', $this->getStringTranslationStub());
+    $container->set('url_generator', $this->createMock(UrlGeneratorInterface::class));
+    $container->set('path.validator', $path_validator);
+    $container->set('unrouted_url_assembler', $unrouted_url_assembler);
     \Drupal::setContainer($container);
   }
 
@@ -122,6 +138,154 @@ class IntegrationReportControllerTest extends UnitTestCase {
 
     $controller = IntegrationReportController::create($container);
     $this->assertInstanceOf(IntegrationReportController::class, $controller);
+  }
+
+  /**
+   * Test overview returns the table skeleton when there are no reports.
+   */
+  public function testOverviewEmpty(): void {
+    $manager = $this->createMock(IntegrationReportManager::class);
+    $manager->method('getReports')->willReturn([]);
+
+    $controller = new IntegrationReportController($manager, $this->createMock(RendererInterface::class));
+    $table = $controller->overview();
+
+    $this->assertSame('table', $table['#theme']);
+    $this->assertSame(['', 'Status type', 'Result'], $table['#header']);
+    $this->assertSame([], $table['#rows']);
+    $this->assertSame('', $table['#suffix']);
+    $this->assertSame(['integration-report-table'], $table['#attributes']['class']);
+    $this->assertSame(['integration_report/integration_report'], $table['#attached']['library']);
+    $this->assertNotEmpty((string) $table['#empty']);
+  }
+
+  /**
+   * Test overview skips reports whose access() returns FALSE.
+   */
+  public function testOverviewSkipsInaccessibleReports(): void {
+    $allowed = $this->createMock(IntegrationReportInterface::class);
+    $allowed->method('access')->willReturn(TRUE);
+    $allowed->method('getJs')->willReturn(NULL);
+    $allowed->method('isUseCallback')->willReturn(FALSE);
+    $allowed->method('statusPage')->willReturn('');
+    $allowed->method('getName')->willReturn('Allowed');
+    $allowed->method('getDescription')->willReturn('Allowed Description');
+
+    $denied = $this->createMock(IntegrationReportInterface::class);
+    $denied->method('access')->willReturn(FALSE);
+    $denied->expects($this->never())->method('getJs');
+    $denied->expects($this->never())->method('isUseCallback');
+    $denied->expects($this->never())->method('statusPage');
+
+    $manager = $this->createMock(IntegrationReportManager::class);
+    $manager->method('getReports')->willReturn([$allowed, $denied]);
+
+    $controller = new IntegrationReportController($manager, $this->createMock(RendererInterface::class));
+    $table = $controller->overview();
+
+    $this->assertCount(1, $table['#rows']);
+  }
+
+  /**
+   * Test overview appends inline JS when a report exposes a js path.
+   */
+  public function testOverviewAttachesJsScript(): void {
+    $report = $this->createMock(IntegrationReportInterface::class);
+    $report->method('access')->willReturn(TRUE);
+    $report->method('getJs')->willReturn('/modules/example/js/example.js');
+    $report->method('isUseCallback')->willReturn(FALSE);
+    $report->method('statusPage')->willReturn('');
+    $report->method('getName')->willReturn('JS Report');
+    $report->method('getDescription')->willReturn('Has JS');
+
+    $manager = $this->createMock(IntegrationReportManager::class);
+    $manager->method('getReports')->willReturn([$report]);
+
+    $renderer = $this->createMock(RendererInterface::class);
+    $renderer->method('render')->willReturn(Markup::create('<script src="/modules/example/js/example.js"></script>'));
+
+    $controller = new IntegrationReportController($manager, $renderer);
+    $table = $controller->overview();
+
+    $this->assertStringContainsString('<script', (string) $table['#suffix']);
+    $this->assertStringContainsString('/modules/example/js/example.js', (string) $table['#suffix']);
+  }
+
+  /**
+   * Test overview appends an iframe when a report uses the callback flow.
+   */
+  public function testOverviewAttachesIframeWhenCallback(): void {
+    $report = $this->createMock(IntegrationReportInterface::class);
+    $report->method('access')->willReturn(TRUE);
+    $report->method('getJs')->willReturn(NULL);
+    $report->method('isUseCallback')->willReturn(TRUE);
+    $report->method('isSecureCallback')->willReturn(FALSE);
+    $report->method('statusPage')->willReturn('');
+    $report->method('getName')->willReturn('Iframe Report');
+    $report->method('getDescription')->willReturn('Has iframe');
+
+    $manager = $this->createMock(IntegrationReportManager::class);
+    $manager->method('getReports')->willReturn([$report]);
+
+    $controller = new IntegrationReportController($manager, $this->createMock(RendererInterface::class));
+    $table = $controller->overview();
+
+    $suffix = (string) $table['#suffix'];
+    $this->assertStringContainsString('<iframe', $suffix);
+    $this->assertStringContainsString('integration-report-debug-result', $suffix);
+    $this->assertStringContainsString('/admin/reports/integrations/', $suffix);
+  }
+
+  /**
+   * Test overview appends report statusPage() markup to the table suffix.
+   */
+  public function testOverviewAppendsStatusPageMarkup(): void {
+    $report = $this->createMock(IntegrationReportInterface::class);
+    $report->method('access')->willReturn(TRUE);
+    $report->method('getJs')->willReturn(NULL);
+    $report->method('isUseCallback')->willReturn(FALSE);
+    $report->method('statusPage')->willReturn('<div class="custom-marker">extra</div>');
+    $report->method('getName')->willReturn('Status Page Report');
+    $report->method('getDescription')->willReturn('Has status page');
+
+    $manager = $this->createMock(IntegrationReportManager::class);
+    $manager->method('getReports')->willReturn([$report]);
+
+    $controller = new IntegrationReportController($manager, $this->createMock(RendererInterface::class));
+    $table = $controller->overview();
+
+    $this->assertStringContainsString('custom-marker', (string) $table['#suffix']);
+    $this->assertStringContainsString('extra', (string) $table['#suffix']);
+  }
+
+  /**
+   * Test overview builds a row with the expected class name and markers.
+   */
+  public function testOverviewBuildsRowStructure(): void {
+    $report = $this->createMock(IntegrationReportInterface::class);
+    $report->method('access')->willReturn(TRUE);
+    $report->method('getJs')->willReturn(NULL);
+    $report->method('isUseCallback')->willReturn(FALSE);
+    $report->method('statusPage')->willReturn('');
+    $report->method('getName')->willReturn('Row Report');
+    $report->method('getDescription')->willReturn('Row Description');
+
+    $manager = $this->createMock(IntegrationReportManager::class);
+    $manager->method('getReports')->willReturn([$report]);
+
+    $controller = new IntegrationReportController($manager, $this->createMock(RendererInterface::class));
+    $table = $controller->overview();
+
+    $this->assertCount(1, $table['#rows']);
+    $row = $table['#rows'][0];
+    $this->assertSame(['warning'], $row['class']);
+    $short_name = (new \ReflectionClass($report))->getShortName();
+    $this->assertSame($short_name, $row['data-status-result']);
+    $this->assertCount(3, $row['data']);
+    $this->assertStringContainsString('ajax-progress-throbber', (string) $row['data'][0]['data']);
+    $this->assertStringContainsString('Row Report', (string) $row['data'][1]['data']);
+    $this->assertStringContainsString('Row Description', (string) $row['data'][1]['data']);
+    $this->assertNotEmpty((string) $row['data'][2]['data']);
   }
 
 }


### PR DESCRIPTION
## Summary

Added unit test coverage for `IntegrationReportController::overview()`, bringing PHP line coverage to 100% on tracked code (up from 41%). Configured Jest to generate V8 coverage reports written to `.logs/coverage/jest/`, and updated the CI Codecov upload step to include both PHPUnit and Jest cobertura reports. Example module classes are marked `@codeCoverageIgnore` so demonstration-only code is excluded from coverage metrics.

## Changes

### Tests - `IntegrationReportControllerTest`

Six new test methods cover all meaningful branches of `overview()`: empty report list, access-denied skip, JS script attachment, iframe callback attachment, `statusPage()` suffix appending, and full row structure. The `setUp()` method now registers `string_translation`, `url_generator`, `path.validator`, and `unrouted_url_assembler` service mocks in the container so `Url::fromUserInput()` resolves correctly in unit tests without a full Drupal bootstrap.

### Jest coverage - `jest.config.js`

Switched from no-coverage mode to V8 coverage. `rootDir` is anchored at the project root (one level above `build/`) so V8 can track source files that live outside the build directory. Coverage output goes to `.logs/coverage/jest/` with `text`, `html`, and `cobertura` reporters. `modulePaths` is pointed at the local `node_modules` so Jest resolves modules correctly regardless of `rootDir`.

### CI - `.github/workflows/test.yml`

The artifact upload path is widened from `.logs/coverage/phpunit/.coverage-html` to the entire `.logs/coverage` directory so both PHPUnit HTML and Jest HTML reports are captured. The Codecov upload `files` list now includes `.logs/coverage/jest/cobertura.xml` alongside the PHPUnit cobertura file.

### Example classes - `IntegrationReportExample1.php`, `IntegrationReportExample2.php`

Added `@codeCoverageIgnore` to both class docblocks. These classes are demonstration code that is not exercised by the test suite; ignoring them avoids misleading gaps in coverage reports.

## Before / After

```
Before
──────
PHPUnit tests                          Jest tests
     │                                      │
     ▼                                      ▼
.logs/coverage/phpunit/            (no coverage output)
  cobertura.xml ──────────────────► Codecov (PHPUnit only)
  .coverage-html ──► CI artifact
                     (phpunit dir only)

PHP line coverage: ~41%  (85/205 lines - example classes counted)
JS coverage:       none reported


After
─────
PHPUnit tests                          Jest tests (V8)
     │                                      │
     ▼                                      ▼
.logs/coverage/phpunit/        .logs/coverage/jest/
  cobertura.xml ─────┐           cobertura.xml ──┐
  .coverage-html     │           .coverage-html  │
                     └──────────────────────────►Codecov
                                                 (PHPUnit + Jest)
.logs/coverage/ ──────────────────────────► CI artifact
                                            (full coverage dir)

PHP line coverage: 100%  (157/157 tracked lines - example classes excluded)
JS coverage:       90.08% statements / 96.66% branches
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Added comprehensive unit test coverage for `IntegrationReportController::overview()`, configured Jest V8 code coverage tracking, and enabled Codecov uploads for JavaScript coverage alongside existing PHPUnit coverage.

### Key Changes

**Test Coverage** (`tests/src/Unit/Controller/IntegrationReportControllerTest.php`)
- Added six new test methods covering all meaningful branches of the `overview()` method:
  - `testOverviewEmpty()`: Validates rendered table skeleton when report list is empty
  - `testOverviewSkipsInaccessibleReports()`: Verifies access-denied reports are skipped
  - `testOverviewAttachesJsScript()`: Tests inline JS attachment for reports with JS paths
  - `testOverviewAttachesIframeWhenCallback()`: Validates iframe attachment for callback-based reports
  - `testOverviewAppendsStatusPageMarkup()`: Confirms `statusPage()` suffix appending to table markup
  - `testOverviewBuildsRowStructure()`: Verifies correct row structure with expected classes and data markers
- Expanded `setUp()` to register additional service mocks: `path.validator`, `unrouted_url_assembler`, `url_generator`, and `string_translation` to enable `Url::fromUserInput()` resolution without full Drupal bootstrap

**Jest Configuration** (`jest.config.js`)
- Enabled V8 code coverage provider with customized configuration
- Set `rootDir` to project root to track sources outside `build/` directory
- Added `modulePaths` configuration pointing to local `node_modules` for correct module resolution
- Configured coverage output to `.logs/coverage/jest/` with text, HTML, and Cobertura reporters
- Updated test root discovery to use `fs.realpathSync()` for consistent path resolution
- Reported JS coverage: 90.08% statements and 96.66% branches

**CI/CD Updates** (`.github/workflows/test.yml`)
- Modified artifact upload step to include entire `.logs/coverage` directory (previously uploaded only PHPUnit HTML coverage)
- Updated Codecov upload step to process both PHPUnit and Jest Cobertura files:
  - `.logs/coverage/phpunit/cobertura.xml`
  - `.logs/coverage/jest/cobertura.xml`

**Code Coverage Annotations**
- Added `@codeCoverageIgnore` to `IntegrationReportExample1` and `IntegrationReportExample2` classes to exclude demonstration-only code from coverage metrics
- Achieved 100% PHP line coverage for tracked lines (157/157) by excluding example classes

### Impact
This PR raises tracked PHP line coverage from ~41% to 100% and integrates JavaScript coverage tracking into the continuous integration pipeline, enabling comprehensive code quality monitoring across both PHP and JavaScript components. It builds on the unit testing foundation established in PR `#51`.

### Possibly related
- PR `#51`: Added unit tests for `IntegrationReportBase`, manager, controller, and JS sanitiser
- PR `#28`: Added FunctionalJavascript test for iframe-based integration report status flow

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AlexSkrypnyk/integration_report/pull/52?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->